### PR TITLE
Add survey list with actions on homepage

### DIFF
--- a/app/javascript/components/Home.js
+++ b/app/javascript/components/Home.js
@@ -4,6 +4,9 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography'
 import Card from '@mui/material/Card'
 import { createTheme, ThemeProvider, styled } from '@mui/material/styles';
+import SurveyList from './SurveyList';
+import SurveyListActions from './SurveyListActions'
+
 
 const darkTheme = createTheme({ palette: { mode: 'dark' } });
 const lightTheme = createTheme({ palette: { mode: 'light' } });
@@ -17,6 +20,9 @@ const Home = () => {
                 </Typography> 
                 <Paper variant="outlined" />
             </ThemeProvider>
+            <br/>
+            <br/>
+            <SurveyList></SurveyList>
         </Card>
     )
 }

--- a/app/javascript/components/SurveyList.js
+++ b/app/javascript/components/SurveyList.js
@@ -90,8 +90,8 @@ export default function SurveyList() {
                     {survey.title}
                   </TableCell>
                   <TableCell align="right">{survey.isLive ? "True": "False"}</TableCell>
-                  <TableCell align="right">{survey.wentLiveAt ? moment(survey.wentLiveAt).utc().format("MMM D, YYYY HH:mm:ss") : "-"}</TableCell>
-                  <TableCell align="right">{survey.wentLiveAt ? moment(survey.wentLiveAt).utc().format("MMM D, YYYY HH:mm:ss") : "-"}</TableCell>
+                  <TableCell align="right">{survey.wentLiveAt ? moment(survey.wentLiveAt).format("MMM D, YYYY HH:mm:ss") : "-"}</TableCell>
+                  <TableCell align="right">{survey.wentLiveAt ? moment(survey.wentLiveAt).format("MMM D, YYYY HH:mm:ss") : "-"}</TableCell>
                   <TableCell align="right"><SurveyListActions surveyId={survey.id} isLive={survey.isLive}/></TableCell>
               </TableRow>
               ))}

--- a/app/javascript/components/SurveyList.js
+++ b/app/javascript/components/SurveyList.js
@@ -1,0 +1,104 @@
+
+import React, { useState, useEffect} from 'react';
+import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import moment from "moment";
+import SurveyListActions from './SurveyListActions';
+
+
+export default function SurveyList() {
+    const [baseUrl, setBaseUrl] = useState('');
+    const [surveys, setSurveys] = useState([]);
+
+    useEffect(() => {
+      setBaseUrl(window.location.origin.replace(/\/#.*/, ""));
+      fetch(`${baseUrl}/api/v1/surveys/index`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+      })
+      .then(checkRequest)
+      .then(data => {
+          setSurveys(data);
+      })
+    .catch(console.log);
+    }, [])
+
+    const columns = [
+      { id: 'title', label: 'Title', minWidth: 170 },
+      { id: 'live', label: 'Live', minWidth: 50 },
+      {
+        id: 'liveDate',
+        label: 'Live\u00a0Date',
+        minWidth: 100,
+        align: 'right',
+      },
+      {
+        id: 'closedOnDate',
+        label: 'Closed\u00a0On\u00a0Date',
+        minWidth: 100,
+        align: 'right',
+      },
+      {
+        id: 'actions',
+        label: 'Actions',
+        minWidth: 100,
+        align: 'right',
+      },
+    ];
+    
+    const checkRequest = (res) => {
+      if (res.status === 200) {
+          return res.json();
+      } else {
+          throw res;
+      }
+    }
+
+    return (
+      <div>
+        <Paper sx={{ width: '100%', overflow: 'hidden' }}>
+        <TableContainer sx={{ maxHeight: 640 }}>
+          <Table stickyHeader aria-label="sticky table">
+            <TableHead>
+              <TableRow>
+                {columns.map((column) => (
+                  <TableCell
+                    key={column.id}
+                    align={column.align}
+                    style={{ minWidth: column.minWidth }}
+                  >
+                    {column.label}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {console.log(surveys)}
+              {surveys.map((survey) => (
+                <TableRow
+                key={survey.id}
+                sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                >
+                  <TableCell component="th" scope="row">
+                    {survey.title}
+                  </TableCell>
+                  <TableCell align="right">{survey.isLive ? "True": "False"}</TableCell>
+                  <TableCell align="right">{survey.wentLiveAt ? moment(survey.wentLiveAt).utc().format("MMM D, YYYY HH:mm:ss") : "-"}</TableCell>
+                  <TableCell align="right">{survey.wentLiveAt ? moment(survey.wentLiveAt).utc().format("MMM D, YYYY HH:mm:ss") : "-"}</TableCell>
+                  <TableCell align="right"><SurveyListActions surveyId={survey.id} isLive={survey.isLive}/></TableCell>
+              </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        </Paper>
+      </div>
+    )
+}

--- a/app/javascript/components/SurveyListActions.js
+++ b/app/javascript/components/SurveyListActions.js
@@ -1,0 +1,88 @@
+
+import React, { useState, useEffect} from 'react';
+import { FormControl } from '@mui/material';
+import { Select, MenuItem } from '@mui/material';
+import { useNavigate } from 'react-router-dom'
+
+
+export default function SurveyListActions({key, surveyId, isLive}) {
+    const [baseUrl, setBaseUrl] = useState('');
+    const navigate = useNavigate();
+
+    useEffect(() => {
+      setBaseUrl(window.location.origin.replace(/\/#.*/, ""));
+    }, [])
+
+    const checkRequest = (res) => {
+      if (res.status === 200) {
+          return res.json();
+      } else {
+          throw res;
+      }
+    }
+
+    const handleChange = (e) => {
+      let action = e.target.value
+      if (action == "respond") {
+        navigate("/survey/" + surveyId)
+      } else if (action == "close") {
+        const survey = {
+          survey: {
+            isLive: false
+          }
+        }
+        fetch(`${baseUrl}/api/v1/surveys/${surveyId}`, {
+          method: 'PATCH',
+          body: JSON.stringify(survey),
+          headers: {
+              'Content-Type': 'application/json'
+          },
+        })
+        .then(checkRequest)
+        .then(data => {
+            console.log(data);
+            console.log("Closed the survey");
+            navigate("/surveyResponses/" + surveyId)
+        })
+        .catch(console.log);
+      } else if (action == "view") {
+        navigate("/surveyResponses/" + surveyId)
+      } else {
+        console.log("Error");
+      }
+    }
+
+    return (
+      <div>
+        <FormControl fullWidth>
+            { isLive ? 
+              (
+                <Select
+                  labelId="demo-simple-select-label"
+                  id="demo-simple-select"
+                  value={""}
+                  label="Actions"
+                  onChange={handleChange}
+                >
+                  <MenuItem value={"respond"}>Respond to</MenuItem>
+                  <MenuItem value={"close"}>Close survey</MenuItem>
+                  <MenuItem value={"view"} disabled>View Metrics</MenuItem>
+                </Select>
+              ) : (
+                <Select
+                  labelId="demo-simple-select-label"
+                  id="demo-simple-select"
+                  value={""}
+                  label="Actions"
+                  onChange={handleChange}
+                >
+                  <MenuItem value={"respond"} disabled>Respond to</MenuItem>
+                  <MenuItem value={"close"} disabled>Close survey</MenuItem>
+                  <MenuItem value={"view"}>View Metrics</MenuItem>
+                  </Select>
+              )
+            }
+        </FormControl>
+      </div>
+    )
+}

--- a/app/javascript/components/SurveyListActions.js
+++ b/app/javascript/components/SurveyListActions.js
@@ -3,10 +3,13 @@ import React, { useState, useEffect} from 'react';
 import { FormControl } from '@mui/material';
 import { Select, MenuItem } from '@mui/material';
 import { useNavigate } from 'react-router-dom'
+import Modal from './Modal';
 
 
 export default function SurveyListActions({key, surveyId, isLive}) {
     const [baseUrl, setBaseUrl] = useState('');
+    const [openFailure, setOpenFailure] = useState(false);
+    const [error, setError] = useState('');
     const navigate = useNavigate();
 
     useEffect(() => {
@@ -19,6 +22,14 @@ export default function SurveyListActions({key, surveyId, isLive}) {
       } else {
           throw res;
       }
+    }
+
+    const handleOpenFailure = () => {
+        setOpenFailure(true);
+    }
+
+    const handleCloseFailure = () => {
+        setOpenFailure(false);
     }
 
     const handleChange = (e) => {
@@ -40,9 +51,13 @@ export default function SurveyListActions({key, surveyId, isLive}) {
         })
         .then(checkRequest)
         .then(data => {
-            console.log(data);
-            console.log("Closed the survey");
+          if (!data.error && !data.notice) {
             navigate("/surveyResponses/" + surveyId)
+          } else {
+            console.log("\n Error: " + (data.error || data.notice));
+            setError(data.error || data.notice);
+            handleOpenFailure();
+          }
         })
         .catch(console.log);
       } else if (action == "view") {
@@ -83,6 +98,7 @@ export default function SurveyListActions({key, surveyId, isLive}) {
               )
             }
         </FormControl>
+        <Modal open={openFailure} handleClose={handleCloseFailure} title={"Failure"} message={`Error: ${error}`}/>
       </div>
     )
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/webpacker": "5.4.3",
     "antd": "^4.18.7",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
+    "moment": "^2.29.1",
     "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4971,7 +4971,7 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.24.0, moment@^2.25.3:
+moment@^2.24.0, moment@^2.25.3, moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
Closes https://github.com/AashnaNarang/SYSC4806/issues/67

- List of surveys on the homepage and actions
- If the survey is live, you can pick the first two options
- If the survey is not live, then you can only view metrics

![image](https://user-images.githubusercontent.com/46693188/161307750-07fed8cf-84b2-4acc-aef7-5a3694538718.png)

Error handling if failed to update survey (this error shouldn't pop up once other tasks are done but added error handling just in case):
![image](https://user-images.githubusercontent.com/46693188/161314189-9991391b-61e6-4fd2-a4ff-4518b42e33ee.png)
